### PR TITLE
Marie Help Request Front End Implementation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14102,13 +14102,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001431",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -45547,9 +45553,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
+      "version": "1.0.30001431",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,7 @@ import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 
 import HelpRequestIndexPage from "main/pages/HelpRequest/HelpRequestIndexPage";
+import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -54,6 +55,7 @@ function App() {
           hasRole(currentUser, "ROLE_USER") && (
             <>
               <Route exact path="/helpRequest/list" element={<HelpRequestIndexPage />} />
+              <Route exact path="/helprequest/create" element={<HelpRequestCreatePage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,6 +18,8 @@ import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 
+import HelpRequestIndexPage from "main/pages/HelpRequest/HelpRequestIndexPage";
+import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,11 +11,11 @@ import DiningCommonsIndexPage from "main/pages/DiningCommons/DiningCommonsIndexP
 import DiningCommonsCreatePage from "main/pages/DiningCommons/DiningCommonsCreatePage";
 import DiningCommonsEditPage from "main/pages/DiningCommons/DiningCommonsEditPage";
 
-
 import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 
+import HelpRequestIndexPage from "main/pages/HelpRequest/HelpRequestIndexPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -47,6 +47,13 @@ function App() {
           hasRole(currentUser, "ROLE_USER") && (
             <>
               <Route exact path="/diningCommons/list" element={<DiningCommonsIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/helpRequest/list" element={<HelpRequestIndexPage />} />
             </>
           )
         }

--- a/frontend/src/fixtures/helpRequestFixtures.js
+++ b/frontend/src/fixtures/helpRequestFixtures.js
@@ -1,0 +1,43 @@
+const helpRequestFixtures = {
+    oneRequest: {
+        "id": 1,
+        "requesterEmail": "sam@ucsb.edu",
+        "teamId": "7pm-1",
+        "tableOrBreakoutRoom": "Table 3",
+        "requestTime": "2022-01-02T12:00:00",
+        "explanation": "Need Help with Merge Conflicts",
+        "solved": "false"
+    },
+    threeRequests: [
+        {
+            "id": 1,
+            "requesterEmail": "sam@ucsb.edu",
+            "teamId": "7pm-1",
+            "tableOrBreakoutRoom": "Table 3",
+            "requestTime": "2022-01-02T12:00:00",
+            "explanation": "Need Help with Merge Conflicts",
+            "solved": "true"
+        },
+        {
+            "id": 2,
+            "requesterEmail": "JavaScript@ucsb.edu",
+            "teamId": "5pm-3",
+            "tableOrBreakoutRoom": "Table 1",
+            "requestTime": "2022-04-03T12:00:00",
+            "explanation": "Question about Swagger",
+            "solved": "true"
+        },
+        {
+            "id": 3,
+            "requesterEmail": "taya@ucsb.edu",
+            "teamId": "6pm-2",
+            "tableOrBreakoutRoom": "Breakout room 6pm-2",
+            "requestTime": "2022-07-04T12:00:00",
+            "explanation": "Need Help With Mutation Testing",
+            "solved": "false"
+        }
+    ]
+};
+
+
+export { helpRequestFixtures };

--- a/frontend/src/main/components/HelpRequest/HelpRequestForm.js
+++ b/frontend/src/main/components/HelpRequest/HelpRequestForm.js
@@ -1,0 +1,153 @@
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+function HelpRequestForm({ initialHelpRequest, submitAction, buttonLabel="Create" }) {
+
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialHelpRequest || {}, }
+    );
+    // Stryker enable all
+
+    const navigate = useNavigate();
+
+    // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+    // Note that even this complex regex may still need some tweaks
+
+    // Stryker disable next-line Regex
+    const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+
+    // Stryker disable next-line all
+    //const yyyyq_regex = /((19)|(20))\d{2}[1-4]/i; // Accepts from 1900-2099 followed by 1-4.  Close enough.
+
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            {initialHelpRequest && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="id">Code</Form.Label>
+                    <Form.Control
+                        data-testid="HelpRequestForm-id"
+                        id="id"
+                        type="text"
+                        {...register("id")}
+                        value={initialHelpRequest.id}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="requesterEmail">Requester Email</Form.Label>
+                <Form.Control
+                    data-testid="HelpRequestForm-requesterEmail"
+                    id="requesterEmail"
+                    type="text"
+                    isInvalid={Boolean(errors.requesterEmail)}
+                    {...register("requesterEmail", { required: "Email is required."})} />
+                <Form.Control.Feedback type="invalid">
+                    {errors.requesterEmail?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="teamId">TeamId</Form.Label>
+                <Form.Control
+                    data-testid="HelpRequestForm-teamId"
+                    id="teamId"
+                    type="text"
+                    isInvalid={Boolean(errors.name)}
+                    {...register("teamId", {
+                        required: "TeamId is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.teamId?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+            
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="tableOrBreakoutRoom">Table Or BreakoutRoom</Form.Label>
+                <Form.Control
+                    data-testid="HelpRequestForm-tableOrBreakoutRoom"
+                    id="tableOrBreakoutRoom"
+                    type="text"
+                    isInvalid={Boolean(errors.name)}
+                    {...register("tableOrBreakoutRoom", {
+                        required: "Table or BreakoutRoom is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.tableOrBreakoutRoom?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="requestTime">Request Time & Date (iso format)</Form.Label>
+                <Form.Control
+                    data-testid="HelpRequestForm-requestTime"
+                    id="requestTime"
+                    type="text"
+                    isInvalid={Boolean(errors.localDateTime)}
+                    {...register("requestTime", { required: true, pattern: isodate_regex })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.requestTime && 'Request Time & Date is required.'}
+                    {errors.requestTime?.type === 'pattern' && 'requestTime must be in ISO format, e.g. 2022-01-02T15:30'}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="explanation">Explanation</Form.Label>
+                <Form.Control
+                    data-testid="HelpRequestForm-explanation"
+                    id="explanation"
+                    type="text"
+                    isInvalid={Boolean(errors.name)}
+                    {...register("explanation", {
+                        required: "Explanation is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.explanation?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="solved">Solved?</Form.Label>
+                <Form.Check
+                    data-testid="HelpRequestForm-solved"
+                    type="checkbox"
+                    id="solved"
+                    {...register("solved")}
+                />
+            </Form.Group>
+
+
+            <Button
+                type="submit"
+                data-testid="HelpRequestForm-submit"
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid="HelpRequestForm-cancel"
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default HelpRequestForm;

--- a/frontend/src/main/components/HelpRequest/HelpRequestTable.js
+++ b/frontend/src/main/components/HelpRequest/HelpRequestTable.js
@@ -1,0 +1,80 @@
+import OurTable, { ButtonColumn} from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { onDeleteSuccess } from "main/utils/UCSBDateUtils"; //cellToAxiosParamsDelete, 
+// import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/helprequest",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+export default function HelpRequestTable({ request, currentUser }) {
+
+    //const navigate = useNavigate();
+
+    // const editCallback = (cell) => {
+    //     navigate(`/helprequest/edit/${cell.row.values.id}`)
+    // }
+
+    //Stryker disable all : hard to test for query caching
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/helprequest/all"]
+    );
+    //Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Requester Email',
+            accessor: 'requesterEmail',
+        },
+        {
+            Header: 'Team Id',
+            accessor: 'teamId',
+        },
+        {
+            Header: 'Table Or BreakoutRoom',
+            accessor: 'tableOrBreakoutRoom',
+        },
+        {
+            Header: 'Request Time & Date',
+            accessor: 'requestTime',
+        },
+        {
+            Header: 'Explanation',
+            accessor: 'explanation',
+        },
+        {
+            Header: 'Solved?',
+            id: 'solved',
+            accessor: (row, _rowIndex) => String(row.solved) // hack needed for boolean values to show up
+        }
+    ];
+
+    const columnsIfAdmin = [
+        ...columns,
+        //ButtonColumn("Edit", "primary", editCallback, "HelpRequestTable"),
+        ButtonColumn("Delete", "danger", deleteCallback, "HelpRequestTable")
+    ];
+
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+
+    return <OurTable
+        data={request}
+        columns={columnsToDisplay}
+        testid={"HelpRequestTable"}
+    />;
+};

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -65,14 +65,6 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               }
               {
                 hasRole(currentUser, "ROLE_USER") && (
-                  <NavDropdown title="Menu Item Review" id="appnavbar-menu-item-reviews-dropdown" data-testid="appnavbar-menu-item-reviews-dropdown" >
-                    <NavDropdown.Item as={Link} to="/menuitemreviews/list" data-testid="appnavbar-menu-item-reviews-list">List</NavDropdown.Item>
-                    <NavDropdown.Item as={Link} to="/menuitemreviews/create" data-testid="appnavbar-menu-item-reviews-create">Create</NavDropdown.Item>
-                  </NavDropdown>
-                )
-              } 
-              {
-                hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="UCSBDates" id="appnavbar-ucsbdates-dropdown" data-testid="appnavbar-ucsbdates-dropdown" >
                     <NavDropdown.Item as={Link} to="/ucsbdates/list" data-testid="appnavbar-ucsbdates-list">List</NavDropdown.Item>
                     {
@@ -87,6 +79,22 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="Organizations" id="appnavbar-organizations-dropdown" data-testid="appnavbar-organizations-dropdown" >
                     <NavDropdown.Item as={Link} to="/organizations/list" data-testid="appnavbar-organizations-list">List Organizations</NavDropdown.Item>
+                  </NavDropdown>
+                )
+              }
+              {
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="Help Request" id="appnavbar-help-request-dropdown" data-testid="appnavbar-help-request-dropdown" >
+                    <NavDropdown.Item as={Link} to="/helpRequest/list" data-testid="appnavbar-help-request-list">List</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/helpRequest/create" data-testid="appnavbar-help-request-create">Create</NavDropdown.Item>
+                  </NavDropdown>
+                )
+              }
+              {
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="Help Request" id="appnavbar-help-request-dropdown" data-testid="appnavbar-help-request-dropdown" >
+                    <NavDropdown.Item as={Link} to="/helpRequest/list" data-testid="appnavbar-help-request-list">List</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/helpRequest/create" data-testid="appnavbar-help-request-create">Create</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -90,14 +90,6 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   </NavDropdown>
                 )
               }
-              {
-                hasRole(currentUser, "ROLE_USER") && (
-                  <NavDropdown title="Help Request" id="appnavbar-help-request-dropdown" data-testid="appnavbar-help-request-dropdown" >
-                    <NavDropdown.Item as={Link} to="/helpRequest/list" data-testid="appnavbar-help-request-list">List</NavDropdown.Item>
-                    <NavDropdown.Item as={Link} to="/helpRequest/create" data-testid="appnavbar-help-request-create">Create</NavDropdown.Item>
-                  </NavDropdown>
-                )
-              }
   
             </Nav>
             <Nav className="ml-auto">

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -93,8 +93,8 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                {
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="Help Request" id="appnavbar-helprequest-dropdown" data-testid="appnavbar-helprequest-dropdown" >
-                    <NavDropdown.Item as={Link} to="/helpRequest/list" data-testid="appnavbar-helprequest-list">List</NavDropdown.Item>
-                    <NavDropdown.Item as={Link} to="/helpRequest/create" data-testid="appnavbar-helprequest-create">Create</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/helprequest/list" data-testid="appnavbar-helprequest-list">List</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/helprequest/create" data-testid="appnavbar-helprequest-create">Create</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -82,11 +82,19 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   </NavDropdown>
                 )
               }
-              {
+               {
                 hasRole(currentUser, "ROLE_USER") && (
-                  <NavDropdown title="Help Request" id="appnavbar-help-request-dropdown" data-testid="appnavbar-help-request-dropdown" >
-                    <NavDropdown.Item as={Link} to="/helpRequest/list" data-testid="appnavbar-help-request-list">List</NavDropdown.Item>
-                    <NavDropdown.Item as={Link} to="/helpRequest/create" data-testid="appnavbar-help-request-create">Create</NavDropdown.Item>
+                  <NavDropdown title="Menu Item Review" id="appnavbar-menu-item-reviews-dropdown" data-testid="appnavbar-menu-item-reviews-dropdown" >
+                    <NavDropdown.Item as={Link} to="/menuitemreviews/list" data-testid="appnavbar-menu-item-reviews-list">List</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/menuitemreviews/create" data-testid="appnavbar-menu-item-reviews-create">Create</NavDropdown.Item>
+                  </NavDropdown>
+                )
+              } 
+               {
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="Help Request" id="appnavbar-helprequest-dropdown" data-testid="appnavbar-helprequest-dropdown" >
+                    <NavDropdown.Item as={Link} to="/helpRequest/list" data-testid="appnavbar-helprequest-list">List</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/helpRequest/create" data-testid="appnavbar-helprequest-create">Create</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
@@ -1,0 +1,53 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function HelpRequestCreatePage() {
+
+  const objectToAxiosParams = (helpRequest) => ({
+    url: "/api/helprequest/post",
+    method: "POST",
+    params: {
+      requesterEmail: helpRequest.requesterEmail,
+      teamId: helpRequest.teamId,
+      tableOrBreakoutRoom: helpRequest.tableOrBreakoutRoom,
+      requestTime: helpRequest.requestTime,
+      explanation: helpRequest.explanation,
+      solved: helpRequest.solved
+    }
+  });
+
+  const onSuccess = (helpRequest) => {
+    toast(`New helpRequest Created - id: ${helpRequest.id} requesterEmail: ${helpRequest.requesterEmail}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/helprequest/all"]
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess) {
+    return <Navigate to="/helprequest/list" />
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create New HelpRequest</h1>
+
+        <HelpRequestForm submitAction={onSubmit} />
+
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function HelpRequestIndexPage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Help Request</h1>
+        <p>
+          This is where the index page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.js
@@ -1,13 +1,28 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestTable from 'main/components/HelpRequest/HelpRequestTable';
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
 
 export default function HelpRequestIndexPage() {
+
+  const currentUser = useCurrentUser();
+
+  const { data: helpRequest, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/helprequest/all"],
+            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+            { method: "GET", url: "/api/helprequest/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Help Request</h1>
-        <p>
-          This is where the index page will go
-        </p>
+        <h1>UCSB Help Request</h1>
+        <HelpRequestTable request={helpRequest} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/stories/components/HelpRequest/HelpRequestTable.stories.js
+++ b/frontend/src/stories/components/HelpRequest/HelpRequestTable.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import HelpRequestTable from "main/components/HelpRequest/HelpRequestTable";
+import { helpRequestFixtures } from 'fixtures/helpRequestFixtures';
+
+export default {
+    title: 'components/HelpRequest/HelpRequestTable',
+    component: HelpRequestTable
+};
+
+const Template = (args) => {
+    return (
+        <HelpRequestTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    request: []
+};
+
+export const ThreeRequests = Template.bind({});
+
+ThreeRequests.args = {
+    request: helpRequestFixtures.threeRequests
+};
+
+

--- a/frontend/src/tests/components/HelpRequest/HelpRequestForm.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestForm.test.js
@@ -1,0 +1,141 @@
+import { render, waitFor, fireEvent } from "@testing-library/react";
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+
+describe("HelpRequestForm tests", () => {
+
+    test("renders correctly ", async () => {
+
+        const { getByText } = render(
+            <Router  >
+                <HelpRequestForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByText(/Requester Email/)).toBeInTheDocument());
+        await waitFor(() => expect(getByText(/Create/)).toBeInTheDocument());
+    });   
+
+
+    test("renders correctly when passing in a HelpRequest ", async () => {
+
+        const { getByText, getByTestId } = render(
+            <Router  >
+                <HelpRequestForm initialHelpRequest={helpRequestFixtures.oneRequest} />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId(/HelpRequestForm-id/)).toBeInTheDocument());
+        expect(getByText(/Code/)).toBeInTheDocument();
+        expect(getByTestId(/HelpRequestForm-id/)).toHaveValue("1");
+    });
+
+
+    test("Correct Error messsages on bad input", async () => {
+
+        const { getByTestId, getByText } = render(
+            <Router  >
+                <HelpRequestForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("HelpRequestForm-requesterEmail")).toBeInTheDocument());
+        const requesterEmailField = getByTestId("HelpRequestForm-requesterEmail");
+        const teamIdField = getByTestId("HelpRequestForm-teamId");
+        const tableOrBreakoutRoomField = getByTestId("HelpRequestForm-tableOrBreakoutRoom");
+        const requestTimeField = getByTestId("HelpRequestForm-requestTime");
+        const explanationField = getByTestId("HelpRequestForm-explanation");
+        const solvedField = getByTestId("HelpRequestForm-solved");
+        const submitButton = getByTestId("HelpRequestForm-submit");
+
+        fireEvent.change(requesterEmailField, { target: { value: 'bad-input' } });
+        fireEvent.change(teamIdField, { target: { value: 'bad-input' } });
+        fireEvent.change(tableOrBreakoutRoomField, { target: { value: 'bad-input' } });
+        fireEvent.change(requestTimeField, { target: { value: 'bad-input' } });
+        fireEvent.change(explanationField, { target: { value: 'bad-input' } });
+        fireEvent.change(solvedField, { target: { value: 'bad-input' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(getByText(/requestTime must be in ISO format/)).toBeInTheDocument());
+    });
+
+    test("Correct Error messsages on missing input", async () => {
+
+        const { getByTestId, getByText } = render(
+            <Router  >
+                <HelpRequestForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("HelpRequestForm-submit")).toBeInTheDocument());
+        const submitButton = getByTestId("HelpRequestForm-submit");
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(getByText(/Table or BreakoutRoom is required/)).toBeInTheDocument());
+        expect(getByText(/TeamId is required/)).toBeInTheDocument();
+        expect(getByText(/Email is required/)).toBeInTheDocument();
+        expect(getByText(/Request Time & Date is required/)).toBeInTheDocument();
+        expect(getByText(/Explanation is required/)).toBeInTheDocument();
+
+    });
+
+    test("No Error messsages on good input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        const { getByTestId, queryByText } = render(
+            <Router  >
+                <HelpRequestForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("HelpRequestForm-requesterEmail")).toBeInTheDocument());
+
+        const requesterEmailField = getByTestId("HelpRequestForm-requesterEmail");
+        const teamIdField = getByTestId("HelpRequestForm-teamId");
+        const tableOrBreakoutRoomField = getByTestId("HelpRequestForm-tableOrBreakoutRoom");
+        const requestTimeField = getByTestId("HelpRequestForm-requestTime");
+        const explanationField = getByTestId("HelpRequestForm-explanation");
+        const solvedField = getByTestId("HelpRequestForm-solved");
+        const submitButton = getByTestId("HelpRequestForm-submit");
+
+        fireEvent.change(requesterEmailField, { target: { value: 'bob@ucsb.edu' } });
+        fireEvent.change(teamIdField, { target: { value: 'noon on January 2nd' } });
+        fireEvent.change(tableOrBreakoutRoomField, { target: { value: 'Suki the Cat' } });
+        fireEvent.change(requestTimeField, { target: { value: '2022-01-02T12:00' } });
+        fireEvent.change(explanationField, { target: { value: 'food' } });
+        fireEvent.change(solvedField, { target: { value: 'false' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+        expect(queryByText(/requestTime must be in ISO format, e.g. 2022-01-02T15:30/)).not.toBeInTheDocument();
+
+    });
+
+
+    test("Test that navigate(-1) is called when Cancel is clicked", async () => {
+
+        const { getByTestId } = render(
+            <Router  >
+                <HelpRequestForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("HelpRequestForm-cancel")).toBeInTheDocument());
+        const cancelButton = getByTestId("HelpRequestForm-cancel");
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+
+    });
+
+});
+
+

--- a/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
@@ -1,0 +1,121 @@
+import { render } from "@testing-library/react"; //fireEvent, waitFor
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import HelpRequestTable from "main/components/HelpRequest/HelpRequestTable"
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("HelpRequestTable tests", () => {
+  const queryClient = new QueryClient();
+
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable request={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable request={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable request={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable request={helpRequestFixtures.threeRequests} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["id", "Requester Email", "Team Id", "Table Or BreakoutRoom", "Request Time & Date","Explanation","Solved?"];
+    const expectedFields = ["id", "requesterEmail", "teamId", "tableOrBreakoutRoom", "requestTime","explanation","solved"];
+    const testId = "HelpRequestTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    // expect(editButton).toBeInTheDocument();
+    // expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  // test("Edit button navigates to the edit page for admin user", async () => {
+
+  //   const currentUser = currentUserFixtures.adminUser;
+
+  //   const { getByTestId } = render(
+  //     <QueryClientProvider client={queryClient}>
+  //       <MemoryRouter>
+  //         <HelpRequestTable request={helpRequestFixtures.threeRequests} currentUser={currentUser} />
+  //       </MemoryRouter>
+  //     </QueryClientProvider>
+
+  //   );
+
+  //   await waitFor(() => { expect(getByTestId(`HelpRequestTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+    // const editButton = getByTestId(`HelpRequestTable-cell-row-0-col-Edit-button`);
+    // expect(editButton).toBeInTheDocument();
+    // fireEvent.click(editButton);
+    // await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/helprequest/edit/1'));
+
+  // });
+
+});
+

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -333,7 +333,53 @@ describe("AppNavbar tests", () => {
         
     });
 
-    
+    test("renders the helprequest menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-helprequest-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-helprequest-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId("appnavbar-helprequest-list")).toBeInTheDocument() );
+
+    });
+
+    test("renders the help request menu correctly for an admin", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-helprequest-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-helprequest-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-helprequest-create/)).toBeInTheDocument() );
+
+    });
 });
   
 

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
@@ -1,0 +1,118 @@
+import { render, waitFor, fireEvent } from "@testing-library/react";
+import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("HelpRequestCreatePage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const request = {
+            id: 17,
+            requesterEmail: "bob@ucsb.edu",
+            teamId: "6pm-2",
+            tableOrBreakoutRoom: "table 1",
+            requestTime: "2022-02-02T00:00",
+            explanation: "Question about Stryker",
+            solved: false
+        };
+
+        axiosMock.onPost("/api/helprequest/post").reply( 202, request );
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(getByTestId("HelpRequestForm-requesterEmail")).toBeInTheDocument();
+        });
+
+        const requesterEmailField = getByTestId("HelpRequestForm-requesterEmail");
+        const teamIdField = getByTestId("HelpRequestForm-teamId");
+        const tableOrBreakoutRoomField = getByTestId("HelpRequestForm-tableOrBreakoutRoom");
+        const requestTimeField = getByTestId("HelpRequestForm-requestTime");
+        const explanationField = getByTestId("HelpRequestForm-explanation");
+        const solvedField = getByTestId("HelpRequestForm-solved");
+        const submitButton = getByTestId("HelpRequestForm-submit");
+
+        fireEvent.change(requesterEmailField, { target: { value: 'bob@ucsb.edu' } });
+        fireEvent.change(teamIdField, { target: { value: '6pm-3' } });
+        fireEvent.change(tableOrBreakoutRoomField, { target: { value: 'Breakout Room 6pm-3' } });
+        fireEvent.change(requestTimeField, { target: { value: '2022-01-02T12:00' } });
+        fireEvent.change(explanationField, { target: { value: 'Explaining Code Coverage' } });
+        fireEvent.change(solvedField, { target: { value: false } });
+
+        expect(submitButton).toBeInTheDocument(); //try before line 94?
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+                "requesterEmail": 'bob@ucsb.edu',
+                "teamId": '6pm-3',
+                "tableOrBreakoutRoom": 'Breakout Room 6pm-3',
+                "requestTime": '2022-01-02T12:00',
+                "explanation": 'Explaining Code Coverage',
+                "solved": false
+        });
+
+        expect(mockToast).toBeCalledWith("New helpRequest Created - id: 17 requesterEmail: bob@ucsb.edu");
+        expect(mockNavigate).toBeCalledWith({ "to": "/helprequest/list" });
+    });
+
+
+});
+
+

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.js
@@ -1,0 +1,177 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import HelpRequestIndexPage from "main/pages/HelpRequest/HelpRequestIndexPage";
+
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("HelpRequestIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    const testId = "HelpRequestTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/helprequest/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/helprequest/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders three requests without crashing for regular user", async () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/helprequest/all").reply(200, helpRequestFixtures.threeRequests);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+    });
+
+    test("renders three Requests without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/helprequest/all").reply(200, helpRequestFixtures.threeRequests);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/helprequest/all").timeout();
+
+        const _restoreConsole = mockConsole();
+
+        const { getByText, queryByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+        
+        const expectedHeaders = ["id", "Requester Email", "Team Id", "Table Or BreakoutRoom", "Request Time & Date","Explanation","Solved?"];
+
+        expectedHeaders.forEach((headerText) => {
+            const header = getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        
+        //restoreConsole();
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("test what happens when you click delete, admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/helprequest/all").reply(200, helpRequestFixtures.threeRequests);
+        axiosMock.onDelete("/api/helprequest").reply(200, "HelpRequest with id 1 was deleted");
+
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
+
+
+        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+       
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("HelpRequest with id 1 was deleted") });
+
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.js
@@ -147,7 +147,7 @@ describe("HelpRequestIndexPage tests", () => {
 
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/helprequest/all").reply(200, helpRequestFixtures.threeRequests);
-        axiosMock.onDelete("/api/helprequest").reply(200, "HelpRequest with id 1 was deleted");
+        axiosMock.onDelete("/api/helprequest", {params: {id: 1}}).reply(200, "HelpRequest with id 1 was deleted");
 
 
         const { getByTestId } = render(


### PR DESCRIPTION
There is a pull-down menu on the Nav bar with the label Help Request. When that label is clicked, we see a menu with two options: “List, Create”. When the “List Help Requests” option is selected, the browser window goes to the route /helprequest/list When the “Create Help Requests” option is selected, the browser window goes to the route /helprequest/create Removed Duplicate from the previous PR.
Closes #12 and #14 

Implemented Help Request Table as the PR for the above ^ was not passing checks because the placeholder for the index page had no coverage. Closes #16 

Added help request component to storybook and implemented HelpRequest Fixtures with one request and three request options. Closes #15 
<img width="1280" alt="Screen Shot 2022-11-15 at 10 55 23 AM" src="https://user-images.githubusercontent.com/65988599/202002346-05a03670-ee3e-4de2-bd30-79ae5b46c08d.png">


Ran Stryker Mutation Testing and Achieved 100% :
<img width="1280" alt="Screen Shot 2022-11-15 at 10 48 06 AM" src="https://user-images.githubusercontent.com/65988599/202001741-03c24a9e-5355-4b9a-a0a2-c0f5d84cf929.png">

